### PR TITLE
Removed <ol> and made question MC Fixes issue#81

### DIFF
--- a/source/ch11-popularity-contest.ptx
+++ b/source/ch11-popularity-contest.ptx
@@ -814,44 +814,63 @@
 
 				</ul></p>
 
-				<p>
-					<term>Question:</term> The Poisson distribution has a characteristic shape that would be described as:
-				</p>
-
-				<p><ol>
-					<li>
-									<blockquote>
-														<p>
-										Negatively (left) skewed
-									</p>
-									</blockquote>
-					</li>
-
-					<li>
-									<blockquote>
-														<p>
-										Positively (right) skewed
-									</p>
-									</blockquote>
-					</li>
-
-					<li>
-									<blockquote>
-														<p>
-										Symmetric (not skewed)
-									</p>
-									</blockquote>
-					</li>
-
-					<li>
-									<blockquote>
-														<p>
-										None of these
-									</p>
-									</blockquote>
-					</li>
-
-				</ol></p>
+				<exercise label="mc-poisson-shape" xml:id="mc-poisson-shape">
+					<statement>
+						<p>
+							The Poisson distribution has a characteristic shape that would be described as:
+						</p>
+					</statement>
+					<choices>
+						<choice>
+							<statement>
+								<p>
+									Negatively (left) skewed
+								</p>
+							</statement>
+							<feedback>
+								<p>
+									Not quite. Think about where the tail would be when events are rare.
+								</p>
+							</feedback>
+						</choice>
+						<choice correct ="yes">
+							<statement>
+								<p>
+									Positively (right) skewed
+								</p>
+							</statement>
+							<feedback>
+								<p>
+									Correct! The Poisson distribution is typically positively skewed, especially when the mean (λ) is small. As λ increases, the distribution becomes more symmetric, but it still retains a slight right skew.
+								</p>
+							</feedback>
+						</choice>
+						<choice>
+							<statement>
+								<p>
+									Symmetric (not skewed)
+								</p>
+							</statement>
+							<feedback>
+								<p>
+									No, the Poisson distribution is not symmetric, particularly when the mean is small. Only when the mean becomes large does the distribution approach symmetry, resembling a normal distribution.
+								</p>
+							</feedback>
+						</choice>
+						<choice>
+							<statement>
+								<p>
+									None of these
+								</p>
+							</statement>
+							<feedback>
+								<p>
+									Not quite. One of the listed options correctly describes the typical shape of the Poisson distribution, especially when the mean is low. Consider the direction of skewness in the distribution.
+								</p>
+							</feedback>
+						</choice>
+					</choices>
+				</exercise>
 
 			</subsection>
 


### PR DESCRIPTION
Removed all mention of the `ol and changed it to an interactive question
# Description
I used the same question and provided feedback. This is the correct answer, both Google and a couple of other tutor sites, and AI said my answer was accurate. 

### Source

- https://en.wikipedia.org/wiki/Poisson_distribution

- https://app.edutized.com/statistics/which-shape-describes-a-poisson-distribution
- https://chatgpt.com/share/68757546-05b8-800f-a412-16c22c91d477

# Image 
<img width="628" height="467" alt="image" src="https://github.com/user-attachments/assets/896f0f28-4667-4e04-b51e-8d1b05aee18f" />


## Related Issue
fixes issue #81

## How Has This Been Tested?
Built and viewed locally. 
Completed without Peer review at 4:21 Central Time.
