### PR TITLE
Adding decorative tag to the image in Chapter 7

### DIFF
--- a/source/ch7-sample-in-jar.ptx
+++ b/source/ch7-sample-in-jar.ptx
@@ -8,11 +8,7 @@
 
   <introduction>
 
-
-				<figure>
-	<image source="jelly-belly.png" width="40%"/>
-					<caption></caption>
-</figure>
+	<image source="jelly-belly.png" width="40%" decorative="yes"/>
 
 				<p>
 					<idx>sampling distributions</idx>


### PR DESCRIPTION
Solving Issue #98 
The image that needed to be fixed, just needed a decorative tag, and a description would not be necessary. So I have got rid of the figure tag and its caption.

Reviewed by Tristan and Austin
