### PR TITLE
Adds section tags back into the chapters fixes issue #166

### DIFF
--- a/source/ch2-identify-data-problems.ptx
+++ b/source/ch2-identify-data-problems.ptx
@@ -24,7 +24,7 @@
 					To get this domain knowledge you can read or watch videos, but the best way is to ask "subject matter experts" (in this case farmers) about what they do. The whole process of asking questions deserves its own treatment, but for now there are three things to think about when asking questions. First, you want the subject matter experts, or SMEs, as they are sometimes called, to tell stories of what they do. Then you want to ask them about anomalies: the unusual things that happen for better or for worse. Finally, you want to ask about risks and uncertainty: what are the situations where it is hard to tell what will happen next and what happens next could have a profound effect on whether the situation ends badly or well. Each of these three areas of questioning reflects an approach to identifying data problems that may turn up something good that could be accomplished with data, information, and the right decision at the right time.
 				</p>
 </section>
-<subsection xml:id="ch2-stories">
+<section xml:id="ch2-stories">
     <title>Understanding Through Stories</title>
 				<p>
 					The purpose of asking about stories is that people mainly think in stories. From farmers to teachers to managers to CEOs, people know and tell stories about success and failure in their particular domain. Stories are powerful ways of communicating wisdom between different members of the same profession and they are ways of collecting a sense of identity that sets one profession apart from another profession. The only problem is that stories can be wrong.
@@ -37,9 +37,9 @@
 				<p>
 					For example, the farmer might say that in the deep spring frost that occurred five years ago, the trees in the hollow were spared frost damage while the trees around the ridge of the hill had more damage. For this reason, on a cold night the farmer places most of the smudgepots (containers that hold a fuel that creates a smoky fire) around the ridge. The farmer strongly believes that this strategy works, but does it? It would be possible to collect time-series temperature data from multiple locations within the orchard on cold and warm nights, and on nights with and without smudgepots. The data could be used to create a model of temperature changes in the different areas of the orchard and this model could support, improve, or debunk the story.
 				</p>
-</subsection>
+</section>
 
-  <subsection xml:id="ch2-anomalies">
+  <section xml:id="ch2-anomalies">
     <title>Identifying Anomalies</title>
 				<p>
 					A second strategy for problem identification is to look for the exception cases, both good and bad. A little later in the book we will learn about how the core of classic methods of statistical inference is to characterize "the center" the most typical cases that occur and then examine the extreme cases that are far from the center for information that could help us understand an intervention or an unusual combination of circumstances. Identifying unusual cases is a powerful way of understanding how things work, but it is necessary first to define the central or most typical occurrences in order to have an accurate idea of what constitutes an unusual case.
@@ -52,9 +52,9 @@
 				<p>
 					A systematic count of lost fruit underneath a random sample of trees would help to answer this question. The bulk of the trees would probably have each lost about the same amount, but more importantly, that "typical" group would give us a yardstick against which we could determine what would really count as unusual. When we found an unusual set of cases that was truly beyond the limits of typical, we could rightly focus our attention on these to try to understand the anomaly.
 				</p>
-</subsection>
+</section>
 
-  <subsection xml:id="ch2-risk-uncertainty">
+  <section xml:id="ch2-risk-uncertainty">
     <title>Addressing Risk and Uncertainty</title>
 				<p>
 					A third strategy for identifying data problems is to find out about risk and uncertainty. If you read the previous chapter you may remember that a basic function of information is to reduce uncertainty. It is often valuable to reduce uncertainty because of how risk affects the things we all do. At work, at school, at home, life is full of risks: making a decision or failing to do so sets off a chain of events that may lead to something good or something not so good. It is difficult to say, but in general we would like to narrow things down in a way that maximizes the chances of a good outcome and minimizes the chance of a bad one. To do this, we need to make better decisions and to make better decisions we need to reduce uncertainty. By asking questions about risks and uncertainty (and decisions) a data scientist can zero in on the problems that matter. You can even look at the previous two strategies asking about the stories that comprise professional wisdom and asking about anomalies/unusual cases in terms of the potential for reducing uncertainty and risk.
@@ -68,6 +68,6 @@
 					
 				</p>
 
-  </subsection>
+  </section>
 
 </chapter>

--- a/source/ch8-big-data-big-deal.ptx
+++ b/source/ch8-big-data-big-deal.ptx
@@ -3,7 +3,7 @@
 <chapter xml:id="ch8-big-data-big-deal" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Big Data? Big Deal!</title>
 
-  <subsection xml:id="big-data-big-deal">
+  <section xml:id="big-data-big-deal">
     <title>Big Data? Big Deal!</title>
 
   <introduction>
@@ -131,9 +131,9 @@
 					Putting this all together, we can take a sensible position that high quality data, in abundance, together with tools used by intelligent analysts in a secure environment, may provide worthwhile benefits in the commercial sector, in education, in government, and in other areas. The focus of our efforts as data scientists, however, should not be on achieving the largest possible data sets, but rather on getting the right data and the right amount of data for the purpose we intend. There is no special virtue in having a lot of data if those data are unsuitable to the conclusions that we want to draw. Likewise, simply getting data more quickly does not guarantee that what we get will be highly relevant to our problems. Finally, although it is said that variety is the spice of life, complexity is often a danger to reliability and trustworthiness: the more complex the linkages among our data the more likely it is that problems may crop up in making use of those data or keeping them safe.
 				</p>
 
-			</subsection>
+			</section>
 
-		<subsection xml:id="the-tools-of-data-science">
+		<section xml:id="the-tools-of-data-science">
 			<title>The Tools of Data Science </title>
 
 			<p>
@@ -152,8 +152,8 @@
 				R, SPSS, and SAS grew up as statistics packages, but there are also many general purpose programming languages that incorporate features valuable to data scientists. One very exciting development in programming languages has the odd name of "Processing." <idx>processing</idx><term>Processing</term> is a programming language specifically geared toward creating data visualizations. Like R, Processing is an open source project, so it is freely available at <url href="http://processing.org/">http://processing.org/</url>. Also like R, Processing is a cross-platform program, so it will run happily on Mac, Windows, and Linux. There are lots of books available for learning Processing and the website contains lots of examples for getting started. Besides R, Processing might be one of the most important tools in the data scientist’s toolbox, at least for those who need to use data to draw conclusions and communicate with others.
 			</p>
 
-    </subsection>
-			<subsection xml:id="chapter-challenge-4">
+    </section>
+			<section xml:id="chapter-challenge-4">
 				<title>Chapter Challenge </title>
 
 				<p>
@@ -168,9 +168,9 @@
 					and download a trial version of the "World Programming System" (WPS). WPS can read SAS code, so you could easily look up the code that you would need in order to read in your Data.gov dataset.
 				</p>
 
-			</subsection>
+			</section>
 
-			<subsection xml:id="sources-5">
+			<section xml:id="sources-5">
 				<title>Sources </title>
 
 				<p><ul>
@@ -199,6 +199,6 @@
 					</li>
 
 				</ul></p>
-        </subsection>
+        </section>
 
 </chapter>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds section tags back into the chapters, fixes issue #166
# Description
<!--- Describe your changes in detail -->
Adds section tags back into chapters 2 and 8. It was not needed for chapter 3. 
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fixes issue #166
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has been built locally and reviewed by @logananglin98 