### PR TITLE
fixes issue #213 I fixed all of the build warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # This file was automatically generated with PreTeXt 2.18.0.
-pretext == 2.18.0
+pretext == 2.22.0

--- a/source/ch9-onward-with-rstudio.ptx
+++ b/source/ch9-onward-with-rstudio.ptx
@@ -499,7 +499,7 @@
 					tf &lt;- tabulate(f)
 					return(as.numeric(levels(f)[tf == max(tf)]))
 					}
-					<sub>&lt;environment: namespace:modeest&gt;</sub>
+					&lt;environment: namespace:modeest&gt;
 				</pre>
 
 				<p>


### PR DESCRIPTION
# Description
the requirements.txt had an older version of pretext listed that was causing a build warning, and there was a sub tag inside of a pre tag in chapter 9 that was also causing a build warning. I just changed the pretext version in reqirements.txt to the current one and removed the sub tags.

## Related Issue
fixes issue #213

## How Has This Been Tested?
this was built and tested and reviewed by @logananglin98 
